### PR TITLE
Get gemfire-lucene built from the lucene extension repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ allprojects {
             }
           }
         }
+        if(project.hasProperty("useMavenLocal")) {
+            mavenLocal()
+        }
         mavenCentral()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@
 #
 version = 10.0.0-build.0
 geodeVersion = 10.0.+
+gemfireLuceneVersion = 1.0.+
 
 # release properties, set these on the command line to validate against
 # a release candidate

--- a/lucene/build.gradle
+++ b/lucene/build.gradle
@@ -15,5 +15,5 @@
  * limitations under the License.
  */
 dependencies {
-  compile("com.vmware.gemfire:geode-lucene:$geodeVersion")
+  compile("com.vmware.gemfire:gemfire-lucene:$gemfireLuceneVersion")
 }

--- a/luceneSpatial/build.gradle
+++ b/luceneSpatial/build.gradle
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 dependencies {
-  compile("com.vmware.gemfire:geode-lucene:$geodeVersion")
+  compile("com.vmware.gemfire:gemfire-lucene:$gemfireLuceneVersion")
   compile("org.apache.lucene:lucene-spatial-extras:6.4.1")
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -65,7 +65,6 @@ if (gradle.ext.usingGeodeCompositeBuild) {
       it.substitute it.module("com.vmware.gemfire:geode-cq") with it.project(':geode-cq')
       it.substitute it.module("com.vmware.gemfire:geode-core") with it.project(':geode-core')
       it.substitute it.module("com.vmware.gemfire:geode-logging") with it.project(':geode-logging')
-      it.substitute it.module("com.vmware.gemfire:geode-lucene") with it.project(':geode-lucene')
       it.substitute it.module("com.vmware.gemfire:apache-geode") with it.project(':geode-assembly')
     }
   }


### PR DESCRIPTION
This changes the examples to pull gemfire-lucene from it's new maven
coordinates which are built by the lucene-extension pipeline.