### PR TITLE
GEM-4365: Add lucene to classpath for gfsh and locator

### DIFF
--- a/lucene/build.gradle
+++ b/lucene/build.gradle
@@ -17,3 +17,14 @@
 dependencies {
   compile("com.vmware.gemfire:gemfire-lucene:$gemfireLuceneVersion")
 }
+
+tasks.named("start") { start ->
+  start.environment ('CLASSPATH', configurations.runtime.asPath)
+}
+
+task copyDependencies(type:Copy) {
+  into "$buildDir/libs"
+  from configurations['runtime']
+}
+
+build.dependsOn(copyDependencies)

--- a/lucene/scripts/start.gfsh
+++ b/lucene/scripts/start.gfsh
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-start locator --name=locator --bind-address=localhost
 
-start server --name=server1 --locators=localhost[10334] --server-port=0 --classpath=../build/classes/java/main --enable-time-statistics --statistic-archive-file=lucene1.gfs
-start server --name=server2 --locators=localhost[10334] --server-port=0 --classpath=../build/classes/java/main --enable-time-statistics --statistic-archive-file=lucene2.gfs
+set variable --name=STAR --value=*
+start locator --name=locator --bind-address=localhost --classpath=../build/libs/${STAR}
+start server --name=server1 --locators=localhost[10334] --server-port=0 --classpath=../build/libs/${STAR} --enable-time-statistics --statistic-archive-file=lucene1.gfs
+start server --name=server2 --locators=localhost[10334] --server-port=0 --classpath=../build/libs/${STAR} --enable-time-statistics --statistic-archive-file=lucene2.gfs
 
 ## simpleIndex uses default Lucene StandardAnalyzer
 create lucene index --name=simpleIndex --region=example-region --field=firstName,lastName

--- a/luceneSpatial/build.gradle
+++ b/luceneSpatial/build.gradle
@@ -19,6 +19,10 @@ dependencies {
   compile("org.apache.lucene:lucene-spatial-extras:6.4.1")
 }
 
+tasks.named("start") { start ->
+  start.environment ('CLASSPATH', configurations.runtime.asPath)
+}
+
 task copyDependencies(type:Copy) {
   into "$buildDir/libs"
   from configurations['runtime']

--- a/luceneSpatial/scripts/start.gfsh
+++ b/luceneSpatial/scripts/start.gfsh
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-start locator --name=locator --bind-address=127.0.0.1
-
 set variable --name=STAR --value=*
+
+start locator --name=locator --bind-address=127.0.0.1 --classpath=../build/libs/${STAR}
 start server --name=server1 --locators=127.0.0.1[10334] --server-port=0 --classpath=../build/libs/${STAR} --enable-time-statistics --statistic-archive-file=lucene1.gfs
 start server --name=server2 --locators=127.0.0.1[10334] --server-port=0 --classpath=../build/libs/${STAR} --enable-time-statistics --statistic-archive-file=lucene2.gfs
 


### PR DESCRIPTION
Now that we've removed lucene from gemfire, we need to add it back into the
classpath of both gfsh and the locator for the lucene examples.