### PR TITLE
Excempt IntelliJ license file from rat

### DIFF
--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -41,6 +41,7 @@ rat {
     'etc/eclipse-java-google-style.xml',
     'etc/intellij-java-google-style.xml',
     'etc/eclipseOrganizeImports.importorder',
+    'etc/intellij-vmware-copyright-notice.xml',
     '**/.project',
     '**/.classpath',
     '**/.settings/**',


### PR DESCRIPTION
The intelliJ license header configuration file is xml and somehow doesn't work properly with rat. This commit adds an excemption for that file from rat scanning.