### PR TITLE
Use GEMFIRE_HOME for install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 # VMware GemFire examples
+The examples in this project are showcase features of GemFire and demonstrate their basic usage. For details an all GemFire featues, see [our documentation](https://docs.vmware.com/en/VMware-Tanzu-GemFire/index.html) 
 
-This is the home of VMware GemFire examples.
-
-# VMware GemFire Version
-
+## VMware GemFire Version
 VMware GemFire client code must link against the _same or older_ version of VMware GemFire as the VMware GemFire server it will connect to.
 
 Add `-PgeodeRepositoryUrl=https://commercial-repo.pivotal.io/data3/gemfire-release-repo/gemfire -PgeodeVersion=9.10.15` to your `./gradlew` command to specify which VMware GemFire client libraries to link, otherwise the default may be too new.
 
 ## Running an example
-
-The gradle build will automatically download and install a VMware GemFire release in the
-`build` directory. You can run an example with the following gradle targets:
+In order to execute the examples in this project, follow these steps:
+1. Download the version of GemFire that you want to use as the server from [Tanzu Network](https://network.tanzu.vmware.com/products/pivotal-gemfire/)
+2. Unpack the GemFire TAR file and set your `GEMFIRE_HOME` to point at the directory. If you use bash that might look like this: `export GEODE_HOME=<GemFire directory>`
+3. You can now run an example with the following gradle targets:
 
 * `build` - compiles the example and runs unit tests
 * `start` - initializes the VMware GemFire cluster
@@ -39,14 +38,14 @@ The gradle build will automatically download and install a VMware GemFire releas
 * `stop` - shuts down the cluster
 * `runAll` - invokes start, run, stop
 
-The commands you need to invoke will be given in the `README.md` file. Sample
+The commands you need to run a specific example will be given in the `README.md` file. Sample
 usage:
 
     $ ./gradlew :replicated:start
     $ ./gradlew :replicated:run
     $ ./gradlew :replicated:stop
     $ ./gradlew runAll
-    $ ./gradlew runAll -PgeodeRepositoryUrl=https://commercial-repo.pivotal.io/data3/gemfire-release-repo/gemfire -PgeodeVersion=9.10.15
+    $ ./gradlew runAll -PgeodeRepositoryUrl=https://commercial-repo.pivotal.io/data3/gemfire-release-repo/gemfire -PgeodeVersion=9.15.3
 
 ## Catalog of examples
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,7 @@ allprojects {
     }
 }
 
-def installDir = "$buildDir/apache-geode"
-
+def installDir = System.getenv('GEMFIRE_HOME') ?: System.getenv('GEODE_HOME')
 configurations {
     geodeDistribution
 }
@@ -49,20 +48,6 @@ dependencies {
         targetConfiguration = 'compositeTarget'
       }
     }
-}
-
-task installGeode(type: Copy) {
-    if (gradle.usingGeodeCompositeBuild) {
-        dependsOn(gradle.includedBuild('geode').task(':geode-assembly:distTar'))
-    }
-    from {
-        tarTree(configurations.geodeDistribution.singleFile)
-    }
-    eachFile { fcp ->
-        fcp.path = fcp.path.replaceFirst("^apache-geode-[a-zA-Z0-9\\.\\-]+\\/", "apache-geode/")
-    }
-    into buildDir
-    includeEmptyDirs false
 }
 
 subprojects {
@@ -109,16 +94,14 @@ subprojects {
     clean.finalizedBy cleanServer
 
     def geodePath = "${System.env.PATH}${System.getProperty('path.separator')}${installDir}/bin"
-    task start(type: Exec, dependsOn: [installGeode, build, cleanServer]) {
+    task start(type: Exec, dependsOn: [build, cleanServer]) {
         workingDir projectDir
-        environment 'GEODE_HOME', installDir
         environment 'PATH', geodePath
         commandLine 'sh', '-c', "gfsh run --file=${projectDir}/scripts/start.gfsh"
     }
 
-    task stop(type: Exec, dependsOn: installGeode) {
+    task stop(type: Exec) {
         workingDir projectDir
-        environment 'GEODE_HOME', installDir
         environment 'PATH', geodePath
         commandLine 'sh', '-c', "gfsh run --file=${projectDir}/scripts/stop.gfsh"
     }
@@ -131,7 +114,6 @@ subprojects {
 
     task waitForExitingMembers(type: Exec) {
         workingDir projectDir
-        environment 'GEODE_HOME', installDir
         environment 'PATH', geodePath
         ignoreExitValue true
         commandLine 'sh', '-c', "" +
@@ -159,7 +141,6 @@ subprojects {
 
     task verifyNoMembersRunning(type: Exec) {
         workingDir projectDir
-        environment 'GEODE_HOME', installDir
         environment 'PATH', geodePath
         ignoreExitValue true
         commandLine 'sh', '-c', "echo \"Looking for existing member processes...\" ; " +


### PR DESCRIPTION
Uses GEMFIRE_HOME or GEODE_HOME to find the relevant GemFire installation/download instead of using the automatically downloaded GemFire.

Update Readme to reflect this.