### PR TITLE
GEMRTM-305: improve the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ To link against an older version of GemFire, edit the `gemfireVersion=` line in 
 
 ## Running an example
 In order to execute the examples in this project, follow these steps:
+1. Ensure [JDK 11](https://bell-sw.com/pages/downloads/) is installed (and set JAVA_HOME if it's not the default).  You _can__ also use JDK8, but some individual examples will fail.  JDK17 is not yet supported.
 1. Download the version of GemFire that you want to use as the server from [Tanzu Network](https://network.tanzu.vmware.com/products/pivotal-gemfire/)
-2. Unpack the GemFire TAR file and set your `GEMFIRE_HOME` to point at it. `GEMFIRE_HOME` will be the top level directory inside the extracted GemFire.  For example, if you extracted in /tmp/downloads, export GEMFIRE_HOME=/tmp/downloads/vmware-gemfire-10.0.0
-3. Sign up for the [GemFire Maven repo](https://commercial-repo.pivotal.io/) and follow the instructions there to set up gemfire-examples to use your authentication credentials.  Note: be sure to click on the Gradle tab for gradle-specific instruction; the steps shown by default are for mvn projects only.
-4. You can now run an example with the following gradle targets:
+1. Unpack the GemFire TAR file and set your `GEMFIRE_HOME` to point at it. `GEMFIRE_HOME` will be the top level directory inside the extracted GemFire.  For example, if you extracted in /tmp/downloads, export GEMFIRE_HOME=/tmp/downloads/vmware-gemfire-10.0.0
+1. Sign up for the [GemFire Maven repo](https://commercial-repo.pivotal.io/) and follow the instructions there to set up gemfire-examples to use your authentication credentials.  Note: be sure to click on the Gradle tab for gradle-specific instruction; the steps shown by default are for mvn projects only.
+1. You can now run an example with the following gradle targets:
 
 * `build` - compiles the example and runs unit tests
 * `start` - initializes the VMware GemFire cluster

--- a/README.md
+++ b/README.md
@@ -18,19 +18,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-# VMware GemFire examples
-The examples in this project are showcase features of GemFire and demonstrate their basic usage. For details an all GemFire featues, see [our documentation](https://docs.vmware.com/en/VMware-Tanzu-GemFire/index.html) 
+# VMware GemFire feature examples
+The examples in this project are showcase features of GemFire and demonstrate their basic usage.
+
+For details on all GemFire featues, see [VMware GemFire Documentation](https://docs.vmware.com/en/VMware-GemFire).
 
 ## VMware GemFire Version
 Your client code must link against the _same or older_ version (ignoring patch versions) of VMware GemFire as the VMware GemFire server it will connect to.
 
-For compiling against older versions of GemFire you can add the version like this `-PgemfireVersion=10.0.+` to your `./gradlew` command to specify which VMware GemFire client libraries to link.
+To link against an older version of GemFire, edit the `gemfireVersion=` line in `gradle.properties`.
 
 ## Running an example
 In order to execute the examples in this project, follow these steps:
 1. Download the version of GemFire that you want to use as the server from [Tanzu Network](https://network.tanzu.vmware.com/products/pivotal-gemfire/)
-2. Unpack the GemFire TAR file and set your `GEMFIRE_HOME` to point at it. `GEMFIRE_HOME` will be the top level directory inside the extracted GemFire. If you extracted in /tmp/downloads, GEMFIRE_HOME=/tmp/downloads/vmware-gemfire-10.0.0
-3. Sign up for the GemFire Maven repo and follow the instructions there to set your authentication credentials for the repo in Gradle
+2. Unpack the GemFire TAR file and set your `GEMFIRE_HOME` to point at it. `GEMFIRE_HOME` will be the top level directory inside the extracted GemFire.  For example, if you extracted in /tmp/downloads, export GEMFIRE_HOME=/tmp/downloads/vmware-gemfire-10.0.0
+3. Sign up for the [GemFire Maven repo](https://commercial-repo.pivotal.io/) and follow the instructions there to set up gemfire-examples to use your authentication credentials.  Note: be sure to click on the Gradle tab for gradle-specific instruction; the steps shown by default are for mvn projects only.
 4. You can now run an example with the following gradle targets:
 
 * `build` - compiles the example and runs unit tests


### PR DESCRIPTION
* fix doc link
* be consistent in how users should override properties
* call out which tab to look at in the commercial repo for gradle-specific instructions, since man-specific instructions are shown by default, which won't help gradle projects such as this