### PR TITLE
GEM-5272 Fix log4j dependency version mismatch

### DIFF
--- a/quickstart/001_client_server_introduction/pom.xml
+++ b/quickstart/001_client_server_introduction/pom.xml
@@ -42,13 +42,19 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.2</version>
+      <version>2.19.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.19.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.17.2</version>
+      <version>2.19.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Use log4j 2.19.0 dependencies