### PR TITLE
use dependencyManagement to get best versions of dependencies

### DIFF
--- a/quickstart/001_client_server_introduction/pom.xml
+++ b/quickstart/001_client_server_introduction/pom.xml
@@ -20,7 +20,7 @@
   <repositories>
     <repository>
       <id>gemfire-release-repo</id>
-      <name>Pivotal GemFire Release Repository</name>
+      <name>VMware GemFire Release Repository</name>
       <url>https://commercial-repo.pivotal.io/data3/gemfire-release-repo/gemfire</url>
     </repository>
   </repositories>
@@ -31,36 +31,33 @@
     <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.vmware.gemfire</groupId>
+        <artifactId>gemfire-all-bom</artifactId>
+        <version>10.0.0-beta.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <dependency>
       <groupId>com.vmware.gemfire</groupId>
       <artifactId>gemfire-core</artifactId>
-      <version>10.0.0-beta.1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.19.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.19.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.19.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.vmware.gemfire</groupId>
       <artifactId>gemfire-log4j</artifactId>
-      <version>10.0.0-beta.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
 
     <dependency>

--- a/quickstart/002_client_server_user_objects/pom.xml
+++ b/quickstart/002_client_server_user_objects/pom.xml
@@ -24,47 +24,47 @@
   <repositories>
     <repository>
       <id>gemfire-release-repo</id>
-      <name>Pivotal GemFire Release Repository</name>
+      <name>VMware GemFire Release Repository</name>
       <url>https://commercial-repo.pivotal.io/data3/gemfire-release-repo/gemfire</url>
     </repository>
   </repositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.vmware.gemfire</groupId>
+        <artifactId>gemfire-all-bom</artifactId>
+        <version>10.0.0-beta.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
+
     <dependency>
       <groupId>com.vmware.gemfire</groupId>
       <artifactId>gemfire-core</artifactId>
-      <version>10.0.0-beta.1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.19.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.19.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.19.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.vmware.gemfire</groupId>
       <artifactId>gemfire-log4j</artifactId>
-      <version>10.0.0-beta.1</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/quickstart/003_client_server_json/pom.xml
+++ b/quickstart/003_client_server_json/pom.xml
@@ -26,42 +26,39 @@
 
     <repository>
       <id>gemfire-release-repo</id>
-      <name>Pivotal GemFire Release Repository</name>
+      <name>VMware GemFire Release Repository</name>
       <url>https://commercial-repo.pivotal.io/data3/gemfire-release-repo/gemfire</url>
     </repository>
 
   </repositories>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.vmware.gemfire</groupId>
+        <artifactId>gemfire-all-bom</artifactId>
+        <version>10.0.0-beta.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
 
     <dependency>
       <groupId>com.vmware.gemfire</groupId>
       <artifactId>gemfire-core</artifactId>
-      <version>10.0.0-beta.1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.19.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.19.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.19.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.vmware.gemfire</groupId>
       <artifactId>gemfire-log4j</artifactId>
-      <version>10.0.0-beta.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
 
     <dependency>

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -11,7 +11,7 @@ For details on all GemFire features, see [VMware GemFire Documentation](https://
 ## VMware GemFire Version
 Your client code must link against the _same or older_ version (ignoring patch versions) of VMware GemFire as the VMware GemFire server it will connect to.
 
-To link against a different version of GemFire, edit the `<version>` tag for each com.vmware.gemfire dependency in `pom.xml` in each quickstart.
+To link against a different version of GemFire, edit the `<version>` tag for `gemfire-all-bom` in `pom.xml` in each quickstart.
 
 ## Prerequisites
 


### PR DESCRIPTION
Constraining by GemFire's bom allows both gemfire- modules and transitive dependencies like log4j to be declared without a hardcoded version; mvn uses the bom resolve each to a consistent version, and GemFire version only has to be updated in one place.