### PR TITLE
Allow intellij to load the feature-examples project without GEMFIRE_HOME

### DIFF
--- a/feature-examples/build.gradle
+++ b/feature-examples/build.gradle
@@ -47,18 +47,20 @@ allprojects {
 def installDir = System.getenv('GEMFIRE_HOME') ?: System.getenv('GEODE_HOME')
 
 task checkEnv {
-    if (installDir==null || installDir.isEmpty()) {
-        throw new GradleException("Please export GEMFIRE_HOME=<the top-level directory extracted from your GemFire .tgz> (if this message persists, you may also need to ./gradlew --stop)")
-    } else {
-        println("GemFire directory is $installDir")
-    }
-
-    if (project.getProperty('gemfireRepositoryUrl').contains('commercial-repo.pivotal.io')) {
-        if (!project.hasProperty("gemfireReleaseRepoUser") || gemfireReleaseRepoUser.isEmpty()) {
-            throw new GradleException("Please set gemfireReleaseRepoUser in gradle.properties to the email address you registered at https://commercial-repo.pivotal.io/")
+    doLast {
+        if (installDir == null || installDir.isEmpty()) {
+            throw new GradleException("Please export GEMFIRE_HOME=<the top-level directory extracted from your GemFire .tgz> (if this message persists, you may also need to ./gradlew --stop)")
+        } else {
+            println("GemFire directory is $installDir")
         }
-        if (!project.hasProperty("gemfireReleaseRepoPassword") || gemfireReleaseRepoPassword.isEmpty()) {
-            throw new GradleException("Please set gemfireReleaseRepoPassword in gradle.properties to the https://commercial-repo.pivotal.io/ password for $gemfireReleaseRepoUser")
+
+        if (project.getProperty('gemfireRepositoryUrl').contains('commercial-repo.pivotal.io')) {
+            if (!project.hasProperty("gemfireReleaseRepoUser") || gemfireReleaseRepoUser.isEmpty()) {
+                throw new GradleException("Please set gemfireReleaseRepoUser in gradle.properties to the email address you registered at https://commercial-repo.pivotal.io/")
+            }
+            if (!project.hasProperty("gemfireReleaseRepoPassword") || gemfireReleaseRepoPassword.isEmpty()) {
+                throw new GradleException("Please set gemfireReleaseRepoPassword in gradle.properties to the https://commercial-repo.pivotal.io/ password for $gemfireReleaseRepoUser")
+            }
         }
     }
 }


### PR DESCRIPTION
We added validation to the *configuration* of the checkEnv task. That meant that even parsing the gradle build failed immediately. The validation should happen when the task runs.