### PR TITLE
eliminate --mcast-port

### DIFF
--- a/custom-stats-logger/scripts/startGemFire.sh
+++ b/custom-stats-logger/scripts/startGemFire.sh
@@ -22,7 +22,7 @@ DEFAULT_LOCATOR_MEMORY="--initial-heap=1g --max-heap=1g"
 
 DEFAULT_SERVER_MEMORY="--initial-heap=2g --max-heap=2g"
 
-DEFAULT_JVM_OPTS=" --mcast-port=0"
+DEFAULT_JVM_OPTS=""
 
 LOCATOR_OPTS="${DEFAULT_LOCATOR_MEMORY} ${DEFAULT_JVM_OPTS}"
 LOCATOR_OPTS="${LOCATOR_OPTS} --name=locator_`hostname`"

--- a/feature-examples/wan/scripts/start-ln.gfsh
+++ b/feature-examples/wan/scripts/start-ln.gfsh
@@ -18,27 +18,27 @@
 #
 
 # Start the locator
-start locator --name=locator-ln1 --port=10332 --locators=localhost[10332],localhost[10333] --mcast-port=0 --log-level=config \
+start locator --name=locator-ln1 --port=10332 --locators=localhost[10332],localhost[10333] --log-level=config \
         --http-service-port=7070 \
 	--J=-Dgemfire.remote-locators=localhost[10331] --J=-Dgemfire.distributed-system-id=2 \
 	--J=-Dgemfire.jmx-manager-start=true --J=-Dgemfire.jmx-manager-http-port=8082 \
 	--J=-Dgemfire.jmx-manager-port=1092
 
-start locator --name=locator-ln2 --port=10333 --locators=localhost[10333],localhost[10332] --mcast-port=0 --log-level=config \
+start locator --name=locator-ln2 --port=10333 --locators=localhost[10333],localhost[10332] --log-level=config \
         --http-service-port=7080 \
 	--J=-Dgemfire.remote-locators=localhost[10331] --J=-Dgemfire.distributed-system-id=2 \
 	--J=-Dgemfire.jmx-manager-start=true --J=-Dgemfire.jmx-manager-http-port=8083 \
 	--J=-Dgemfire.jmx-manager-port=1093
 
 # Start server 1
-start server --name=server-ln-1 --locators=localhost[10332],localhost[10333] --mcast-port=0 --log-level=config \
+start server --name=server-ln-1 --locators=localhost[10332],localhost[10333] --log-level=config \
 	--enable-time-statistics=true --statistic-archive-file=cacheserver.gfs --server-port=0 \
 	--classpath=../build/classes/java/main --J=-Dgemfire.statistic-sampling-enabled=true \
 	--J=-Dgemfire.distributed-system-id=2 --J=-Dgemfire.conserve-sockets=false \
 	--J=-Dgemfire.log-file=cacheserver.log --J=-Dgemfire.wait-before-wan-copy=2000
 
 # Start server 2
-start server --name=server-ln-2 --locators=localhost[10332],localhost[10333] --mcast-port=0 --log-level=config \
+start server --name=server-ln-2 --locators=localhost[10332],localhost[10333] --log-level=config \
 	--enable-time-statistics=true --statistic-archive-file=cacheserver.gfs --server-port=0 \
 	--classpath=../build/classes/java/main --J=-Dgemfire.statistic-sampling-enabled=true \
 	--J=-Dgemfire.distributed-system-id=2 --J=-Dgemfire.conserve-sockets=false \

--- a/feature-examples/wan/scripts/start-ny.gfsh
+++ b/feature-examples/wan/scripts/start-ny.gfsh
@@ -18,20 +18,20 @@
 #
 
 # Start the locator
-start locator --name=locator-ny --port=10331 --locators=localhost[10331] --mcast-port=0 --log-level=config \
+start locator --name=locator-ny --port=10331 --locators=localhost[10331] --log-level=config \
 	--J=-Dgemfire.remote-locators=localhost[10332],localhost[10333] --J=-Dgemfire.distributed-system-id=1 \
 	--J=-Dgemfire.jmx-manager-start=true --J=-Dgemfire.jmx-manager-http-port=8081 \
 	--J=-Dgemfire.jmx-manager-port=1091
 
 # Start server 1
-start server --name=server-ny-1 --locators=localhost[10331] --mcast-port=0 --log-level=config \
+start server --name=server-ny-1 --locators=localhost[10331] --log-level=config \
 	--enable-time-statistics=true --statistic-archive-file=cacheserver.gfs --server-port=0 \
 	--classpath=../build/classes/java/main --J=-Dgemfire.statistic-sampling-enabled=true \
 	--J=-Dgemfire.distributed-system-id=1 --J=-Dgemfire.conserve-sockets=false \
 	--J=-Dgemfire.log-file=cacheserver.log
 
 # Start server 2
-start server --name=server-ny-2 --locators=localhost[10331] --mcast-port=0 --log-level=config \
+start server --name=server-ny-2 --locators=localhost[10331] --log-level=config \
 	--enable-time-statistics=true --statistic-archive-file=cacheserver.gfs --server-port=0 \
 	--classpath=../build/classes/java/main --J=-Dgemfire.statistic-sampling-enabled=true \
 	--J=-Dgemfire.distributed-system-id=1 --J=-Dgemfire.conserve-sockets=false \

--- a/feature-examples/wanDelta/scripts/start-ln.gfsh
+++ b/feature-examples/wanDelta/scripts/start-ln.gfsh
@@ -2,20 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Start the locator
-start locator --name=locator-ln --port=10332 --locators=localhost[10332] --mcast-port=0 --log-level=config \
+start locator --name=locator-ln --port=10332 --locators=localhost[10332] --log-level=config \
 	--J=-Dgemfire.remote-locators=localhost[10331] --J=-Dgemfire.distributed-system-id=2 \
 	--J=-Dgemfire.jmx-manager-start=true --J=-Dgemfire.jmx-manager-http-port=8082 \
 	--J=-Dgemfire.jmx-manager-port=1092
 
 # Start server 1
-start server --name=server-ln-1 --locators=localhost[10332] --mcast-port=0 --log-level=config \
+start server --name=server-ln-1 --locators=localhost[10332] --log-level=config \
 	--enable-time-statistics=true --statistic-archive-file=cacheserver.gfs --server-port=0 \
 	--classpath=../build/classes/java/main --J=-Dgemfire.statistic-sampling-enabled=true \
 	--J=-Dgemfire.distributed-system-id=2 --J=-Dgemfire.conserve-sockets=false \
 	--J=-Dgemfire.log-file=cacheserver.log
 
 # Start server 2
-start server --name=server-ln-2 --locators=localhost[10332] --mcast-port=0 --log-level=config \
+start server --name=server-ln-2 --locators=localhost[10332] --log-level=config \
 	--enable-time-statistics=true --statistic-archive-file=cacheserver.gfs --server-port=0 \
 	--classpath=../build/classes/java/main --J=-Dgemfire.statistic-sampling-enabled=true \
 	--J=-Dgemfire.distributed-system-id=2 --J=-Dgemfire.conserve-sockets=false \

--- a/feature-examples/wanDelta/scripts/start-ny.gfsh
+++ b/feature-examples/wanDelta/scripts/start-ny.gfsh
@@ -2,20 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Start the locator
-start locator --name=locator-ny --port=10331 --locators=localhost[10331] --mcast-port=0 --log-level=config \
+start locator --name=locator-ny --port=10331 --locators=localhost[10331] --log-level=config \
 	--J=-Dgemfire.remote-locators=localhost[10332] --J=-Dgemfire.distributed-system-id=1 \
 	--J=-Dgemfire.jmx-manager-start=true --J=-Dgemfire.jmx-manager-http-port=8081 \
 	--J=-Dgemfire.jmx-manager-port=1091
 
 # Start server 1
-start server --name=server-ny-1 --locators=localhost[10331] --mcast-port=0 --log-level=config \
+start server --name=server-ny-1 --locators=localhost[10331] --log-level=config \
 	--enable-time-statistics=true --statistic-archive-file=cacheserver.gfs --server-port=0 \
 	--classpath=../build/classes/java/main --J=-Dgemfire.statistic-sampling-enabled=true \
 	--J=-Dgemfire.distributed-system-id=1 --J=-Dgemfire.conserve-sockets=false \
 	--J=-Dgemfire.log-file=cacheserver.log
 
 # Start server 2
-start server --name=server-ny-2 --locators=localhost[10331] --mcast-port=0 --log-level=config \
+start server --name=server-ny-2 --locators=localhost[10331] --log-level=config \
 	--enable-time-statistics=true --statistic-archive-file=cacheserver.gfs --server-port=0 \
 	--classpath=../build/classes/java/main --J=-Dgemfire.statistic-sampling-enabled=true \
 	--J=-Dgemfire.distributed-system-id=1 --J=-Dgemfire.conserve-sockets=false \


### PR DESCRIPTION
Multicast hasn't been a part of GemFire for a very long time. But for some reason some of our example scripts still had `--mcast-port=0` specified.

This PR eliminates that option from the scripts and makes them compatible with upcoming GemFire versions that don't understand that option.